### PR TITLE
Point the Contribute link at this repo

### DIFF
--- a/src/settings/index.tsx
+++ b/src/settings/index.tsx
@@ -222,7 +222,7 @@ function Toolbar(): JSX.Element {
 				</Button>
 				<Button
 					variant="tertiary"
-					href="https://github.com/troychaplin/block-accessibility-checks"
+					href="https://github.com/annezazu/accessibility-lab"
 					target="_blank"
 					rel="noopener noreferrer"
 					icon={ external }


### PR DESCRIPTION
The **Contribute** button in the settings toolbar linked to `troychaplin/block-accessibility-checks`. That's one of the upstream plugins this plugin adapts validation rules from, not this project — so anyone clicking Contribute landed somewhere they couldn't contribute to Accessibility Lab.

Now points to `https://github.com/annezazu/accessibility-lab`.

## Changes

One line in `src/settings/index.tsx` — the `href` on the Contribute `Button`. The **Docs** button is unchanged and still points at [make.wordpress.org/accessibility](https://make.wordpress.org/accessibility/).

The attribution to Troy Chaplin's plugins is untouched — it stays in the README's Attribution section and in the per-module `credits()` shown on the settings cards, which is the right place for it.

## Testing

Rebuilt and checked on a local wp-env site (WordPress 7.0.4). The rendered toolbar now resolves to:

```
Docs       → https://make.wordpress.org/accessibility/
Contribute → https://github.com/annezazu/accessibility-lab
```

Note this is a `src/` change and `build/` is gitignored, so `npm run build` is needed to pick it up.

Branched from `main` and independent of #4 — the two can merge in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)